### PR TITLE
chore(renovate): enhance renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,40 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":timezone(Asia/Tokyo)",
+    ":approveMajorUpdates",
+    ":automergePatch",
+    ":automergeTypes",
+    ":automergeLinters",
+    ":automergeTesters",
+    ":prHourlyLimitNone",
+    ":maintainLockFilesWeekly",
+    ":semanticCommits"
+  ],
+  "labels": ["renovate"],
+  "schedule": ["after 9am and before 8pm every weekday"],
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "packageRules": [
+    {
+      "description": "Automerge all devDependency updates",
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "description": "Group React and React Native packages",
+      "matchPackagePatterns": ["^react", "^@react-navigation"],
+      "groupName": "React ecosystem",
+      "labels": ["react-ecosystem"],
+      "automerge": false
+    },
+    {
+      "description": "Group Expo packages",
+      "matchPackagePatterns": ["^expo", "^@expo"],
+      "groupName": "Expo ecosystem",
+      "labels": ["expo-ecosystem"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
# Changes

Expanded Renovate configuration to improve dependency management:

- Added timezone (Asia/Tokyo) and restricted schedule (weekdays 9am–8pm)
- Enabled automerge for patch, types, linters, testers, and devDependencies
- Set PR merge type to squash with semantic commits
- Introduced labels for Renovate PRs
- Grouped React ecosystem packages (react, react-native, https://github.com/react-navigation) under `react-ecosystem`
- Grouped Expo ecosystem packages (expo, https://github.com/expo) under `expo-ecosystem`

This makes update behavior more predictable, reduces noise, and keeps dependency updates organized.