### PR TITLE
chore(renovate): Configure Renovate rules for Expo/React

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":timezone(Asia/Tokyo)",
     ":approveMajorUpdates",
     ":automergePatch",
+    ":automergeMinor",
     ":automergeTypes",
     ":automergeLinters",
     ":automergeTesters",
@@ -23,18 +24,27 @@
       "automerge": true
     },
     {
-      "description": "Group React and React Native packages",
-      "matchPackagePatterns": ["^react", "^@react-navigation"],
-      "groupName": "React ecosystem",
-      "labels": ["react-ecosystem"],
-      "automerge": false
+      "description": "Group Expo + React ecosystem",
+      "matchPackagePatterns": [
+        "^expo",
+        "^@expo",
+        "^react",
+        "^@react-navigation"
+      ],
+      "groupName": "Expo + React ecosystem",
+      "labels": ["expo-react-ecosystem"]
     },
     {
-      "description": "Group Expo packages",
-      "matchPackagePatterns": ["^expo", "^@expo"],
-      "groupName": "Expo ecosystem",
-      "labels": ["expo-ecosystem"],
-      "automerge": false
+      "description": "Expo + React major upgrades → require manual merge",
+      "matchPackagePatterns": [
+        "^expo",
+        "^@expo",
+        "^react",
+        "^@react-navigation"
+      ],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["expo-react-major"]
     }
   ]
 }


### PR DESCRIPTION
Configure Expo/React to automerge patch/minor but block major

- Group Expo and React ecosystem packages under a single packageRule
- Allow patch and minor updates for Expo/React to be automerged to reduce unnecessary manual merges
- Prevent automerge of major upgrades for Expo/React to ensure compatibility with Expo SDK
- Keep global policy for other dependencies (patch/minor → automerge, major → manual)