### PR TITLE
ci: add quality checks and scope Renovate to non-Expo deps

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,0 +1,32 @@
+# Quality checks: runs Biome lint, TypeScript type-check, and the Jest test
+# suite on every pull request and on pushes to develop/stage/main. This is the
+# project's quality gate for all changes; dependency PRs (including Renovate)
+# must pass it before automerge.
+name: Quality checks
+
+on:
+  pull_request:
+  push:
+    branches: [develop, stage, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint, type-check, test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npx tsc --noEmit
+      - name: Test
+        run: npm test

--- a/renovate.json
+++ b/renovate.json
@@ -14,58 +14,33 @@
   "automergeStrategy": "squash",
   "packageRules": [
     {
-      "description": "Disable React core packages - must follow Expo SDK compatibility",
+      "description": "Managed by the Expo SDK — update via `expo install --fix`, not Renovate (avoids native incompatibility with the pinned SDK)",
       "matchPackageNames": [
+        "expo",
         "react",
         "react-dom",
         "react-native",
-        "@types/react"
+        "react-test-renderer",
+        "jest",
+        "jest-expo",
+        "@types/react",
+        "/^@expo//",
+        "/^expo-/",
+        "/^react-native/",
+        "/^@react-native/",
+        "/^@react-navigation//"
       ],
       "enabled": false
     },
     {
-      "description": "Expo SDK - group all updates together",
-      "matchPackageNames": ["expo"],
-      "groupName": "Expo SDK",
-      "labels": ["expo-sdk"],
-      "prPriority": 10
-    },
-    {
-      "description": "Expo packages - group all updates together",
-      "matchPackageNames": ["/^@expo//", "/^expo-/"],
-      "excludePackageNames": ["expo"],
-      "groupName": "Expo packages",
-      "labels": ["expo-packages"],
-      "prPriority": 8
-    },
-    {
-      "description": "React Navigation - group all updates together",
-      "matchPackageNames": ["/^@react-navigation/"],
-      "groupName": "React Navigation",
-      "labels": ["react-navigation"],
-      "prPriority": 6
-    },
-    {
-      "description": "React Native ecosystem - group all updates together",
-      "matchPackageNames": ["/^react-native-/", "/^@react-native/"],
-      "groupName": "React Native ecosystem",
-      "labels": ["react-native-ecosystem"],
-      "prPriority": 5
-    },
-    {
-      "description": "Automerge non-breaking changes (patch and minor)",
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
-    },
-    {
-      "description": "Major updates require manual review",
+      "description": "Major updates: hold for manual review via the Dependency Dashboard (no auto PR)",
       "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
       "automerge": false
     },
     {
-      "description": "Automerge devDependencies (except @types/react)",
-      "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["!@types/react"],
+      "description": "Automerge non-breaking updates (patch and minor) once CI passes",
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary
- Add a **Quality checks** GitHub Actions workflow (`.github/workflows/quality-checks.yml`): runs Biome lint, `tsc --noEmit`, and jest on every PR and on pushes to develop/stage/main. This is the project quality gate for all changes and lets Renovate automerge gate on a green check.
- Retune **Renovate** (`renovate.json`):
  - Disable Expo-SDK-managed packages (expo, expo-*, react-native*, @react-native*, @react-navigation/*, jest-expo, react, react-dom, react-test-renderer, @types/react) — these should be updated via `expo install --fix` to stay SDK-compatible, not bumped independently (avoids native incompatibility).
  - Hold **major** updates behind Dependency Dashboard approval (stops the PR pile-up).
  - Keep patch/minor automerge (now gated by the CI check).

## Why
Renovate had accumulated ~10 open PRs, mostly major Expo/RN upgrades that conflict with the intentionally pinned Expo SDK 54. Scoping Renovate to SDK-independent deps + holding majors stops the noise at the source; CI makes the remaining automerge safe.

## Follow-up (after merge)
- Close the now-out-of-scope Renovate PRs (#49, #50, #52, #53, #54, #55, #57, #61); keep #48 (lockfile) and #60 (biome).
- Optional: require the "Quality checks" check in branch protection for develop.

## Test Plan
- [x] `renovate.json` valid JSON, `npm run lint` clean
- [x] CI runs green on this PR (first run of the new workflow)