### PR TITLE
feat: tag chips and last-updated timestamp

### DIFF
--- a/components/recipe/RecipeCard.tsx
+++ b/components/recipe/RecipeCard.tsx
@@ -1,5 +1,6 @@
 import { Image } from "expo-image";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Chip } from "@/components/ui/Chip";
 import { useTheme } from "@/lib/theme/useTheme";
 import type { Recipe } from "@/types/recipe";
 
@@ -39,9 +40,7 @@ export function RecipeCard({
         {recipe.tags.length > 0 && (
           <View style={styles.tags}>
             {recipe.tags.map((tag) => (
-              <Text key={tag} style={{ color: theme.colors.textSecondary }}>
-                {tag}
-              </Text>
+              <Chip key={tag} label={tag} size="small" />
             ))}
           </View>
         )}
@@ -60,7 +59,7 @@ const styles = StyleSheet.create({
     padding: 12,
   },
   thumb: { width: 56, height: 56, borderRadius: 12 },
-  body: { flex: 1, gap: 4 },
+  body: { flex: 1, gap: 6 },
   name: { fontSize: 18, fontWeight: "600" },
   tags: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
 });

--- a/components/recipe/RecipeForm.tsx
+++ b/components/recipe/RecipeForm.tsx
@@ -1,3 +1,4 @@
+import { useHeaderHeight } from "@react-navigation/elements";
 import { usePreventRemove } from "@react-navigation/native";
 import { useNavigation, useRouter } from "expo-router";
 import { useRef } from "react";
@@ -16,7 +17,9 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlourPanel } from "@/components/recipe/form/FlourPanel";
 import { IngredientRow } from "@/components/recipe/form/IngredientRow";
+import { TagChips } from "@/components/recipe/form/TagChips";
 import { bakerPercents } from "@/lib/bakers/calculate";
+import { formatDateTime } from "@/lib/i18n/formatDate";
 import { useT } from "@/lib/i18n/LanguageProvider";
 import { remove, save } from "@/lib/recipes/recipeRepository";
 import { useRecipeForm } from "@/lib/recipes/useRecipeForm";
@@ -30,11 +33,12 @@ function toNumber(text: string): number {
 
 export function RecipeForm({ initial }: { initial: Recipe | null }) {
   const form = useRecipeForm(initial);
-  const { t } = useT();
+  const { t, language } = useT();
   const theme = useTheme();
   const router = useRouter();
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const savedRef = useRef(false);
   const savingRef = useRef(false);
 
@@ -106,7 +110,7 @@ export function RecipeForm({ initial }: { initial: Recipe | null }) {
     <KeyboardAvoidingView
       style={[styles.root, { backgroundColor: theme.colors.background }]}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
-      keyboardVerticalOffset={Platform.OS === "ios" ? 56 : 0}
+      keyboardVerticalOffset={Platform.OS === "ios" ? headerHeight : 0}
     >
       <ScrollView
         style={{ backgroundColor: theme.colors.background }}
@@ -125,6 +129,17 @@ export function RecipeForm({ initial }: { initial: Recipe | null }) {
           placeholderTextColor={theme.colors.textSecondary}
           style={[styles.nameInput, { color: theme.colors.textPrimary }]}
         />
+        {initial && (
+          <Text
+            testID="recipe-timestamp"
+            style={[styles.timestamp, { color: theme.colors.textSecondary }]}
+          >
+            {t("lastUpdated").replace(
+              "{date}",
+              formatDateTime(initial.updatedAt, language),
+            )}
+          </Text>
+        )}
 
         <FlourPanel
           flours={flours}
@@ -173,27 +188,7 @@ export function RecipeForm({ initial }: { initial: Recipe | null }) {
           </Pressable>
         </View>
 
-        <TextInput
-          testID="tags-input"
-          value={form.draft.tags.join(", ")}
-          onChangeText={(x) =>
-            form.setTags(
-              x
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean),
-            )
-          }
-          placeholder={t("tags")}
-          placeholderTextColor={theme.colors.textSecondary}
-          style={[
-            styles.field,
-            {
-              color: theme.colors.textPrimary,
-              borderColor: theme.colors.border,
-            },
-          ]}
-        />
+        <TagChips tags={form.draft.tags} onChange={form.setTags} />
 
         <View style={styles.bakeRow}>
           <TextInput
@@ -338,6 +333,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginTop: 6,
   },
+  timestamp: { fontSize: 12, marginTop: -4 },
   field: {
     borderWidth: 1,
     borderRadius: 12,

--- a/components/recipe/form/TagChips.test.tsx
+++ b/components/recipe/form/TagChips.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { LanguageProvider } from "@/lib/i18n/LanguageProvider";
+import { TagChips } from "./TagChips";
+
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageCode: "en" }],
+}));
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(<LanguageProvider>{ui}</LanguageProvider>);
+
+describe("TagChips", () => {
+  it("renders existing tags as chips", () => {
+    renderWithProvider(
+      <TagChips tags={["lean", "sourdough"]} onChange={() => {}} />,
+    );
+
+    expect(screen.getByTestId("tag-lean")).toBeTruthy();
+    expect(screen.getByTestId("tag-sourdough")).toBeTruthy();
+    expect(screen.getByText("lean")).toBeTruthy();
+    expect(screen.getByText("sourdough")).toBeTruthy();
+  });
+
+  it("shows an add button by default and reveals an input when pressed", () => {
+    renderWithProvider(<TagChips tags={[]} onChange={() => {}} />);
+
+    expect(screen.getByTestId("add-tag")).toBeTruthy();
+    expect(screen.queryByTestId("tag-input")).toBeNull();
+
+    fireEvent.press(screen.getByTestId("add-tag"));
+
+    expect(screen.getByTestId("tag-input")).toBeTruthy();
+  });
+
+  it("appends a new tag when the input is submitted", () => {
+    const onChange = jest.fn();
+    renderWithProvider(<TagChips tags={["lean"]} onChange={onChange} />);
+
+    fireEvent.press(screen.getByTestId("add-tag"));
+    fireEvent.changeText(screen.getByTestId("tag-input"), "sourdough");
+    fireEvent(screen.getByTestId("tag-input"), "submitEditing");
+
+    expect(onChange).toHaveBeenCalledWith(["lean", "sourdough"]);
+  });
+
+  it("trims whitespace and ignores empty submissions", () => {
+    const onChange = jest.fn();
+    renderWithProvider(<TagChips tags={[]} onChange={onChange} />);
+
+    fireEvent.press(screen.getByTestId("add-tag"));
+    fireEvent.changeText(screen.getByTestId("tag-input"), "  rye  ");
+    fireEvent(screen.getByTestId("tag-input"), "submitEditing");
+
+    expect(onChange).toHaveBeenCalledWith(["rye"]);
+    onChange.mockClear();
+
+    fireEvent.press(screen.getByTestId("add-tag"));
+    fireEvent.changeText(screen.getByTestId("tag-input"), "   ");
+    fireEvent(screen.getByTestId("tag-input"), "submitEditing");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("silently ignores duplicate submissions", () => {
+    const onChange = jest.fn();
+    renderWithProvider(<TagChips tags={["lean"]} onChange={onChange} />);
+
+    fireEvent.press(screen.getByTestId("add-tag"));
+    fireEvent.changeText(screen.getByTestId("tag-input"), "lean");
+    fireEvent(screen.getByTestId("tag-input"), "submitEditing");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("removes a tag when its remove button is pressed", () => {
+    const onChange = jest.fn();
+    renderWithProvider(
+      <TagChips tags={["lean", "sourdough"]} onChange={onChange} />,
+    );
+
+    fireEvent.press(screen.getByTestId("remove-tag-lean"));
+
+    expect(onChange).toHaveBeenCalledWith(["sourdough"]);
+  });
+});

--- a/components/recipe/form/TagChips.tsx
+++ b/components/recipe/form/TagChips.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { CHIP_HEIGHT_DEFAULT, Chip } from "@/components/ui/Chip";
+import { useT } from "@/lib/i18n/LanguageProvider";
+import { useTheme } from "@/lib/theme/useTheme";
+
+export function TagChips({
+  tags,
+  onChange,
+}: {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+}) {
+  const theme = useTheme();
+  const { t } = useT();
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const commit = () => {
+    const text = draft.trim();
+    setDraft("");
+    setAdding(false);
+    if (text === "" || tags.includes(text)) {
+      return;
+    }
+    onChange([...tags, text]);
+  };
+
+  const removeAt = (target: string) => {
+    onChange(tags.filter((tag) => tag !== target));
+  };
+
+  return (
+    <View style={styles.wrap}>
+      {tags.map((tag) => (
+        <Chip
+          key={tag}
+          label={tag}
+          testID={`tag-${tag}`}
+          onRemove={() => removeAt(tag)}
+          removeTestID={`remove-tag-${tag}`}
+        />
+      ))}
+      {adding ? (
+        <TextInput
+          testID="tag-input"
+          value={draft}
+          onChangeText={setDraft}
+          autoFocus
+          returnKeyType="done"
+          onSubmitEditing={commit}
+          onBlur={commit}
+          placeholder={t("tags")}
+          placeholderTextColor={theme.colors.textSecondary}
+          style={[
+            styles.input,
+            {
+              color: theme.colors.textPrimary,
+              borderColor: theme.colors.accent,
+            },
+          ]}
+        />
+      ) : (
+        <Pressable
+          testID="add-tag"
+          accessibilityRole="button"
+          accessibilityLabel={t("addTag")}
+          onPress={() => setAdding(true)}
+          style={[
+            styles.addBtn,
+            { height: CHIP_HEIGHT_DEFAULT, borderColor: theme.colors.accent },
+          ]}
+        >
+          <Text
+            style={{ color: theme.colors.accent, fontSize: theme.fontSize.sm }}
+          >
+            ＋ {t("addTag")}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: 8,
+  },
+  addBtn: {
+    borderWidth: 1.5,
+    borderStyle: "dashed",
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  input: {
+    height: CHIP_HEIGHT_DEFAULT,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 0,
+    minWidth: 100,
+    fontSize: 14,
+    textAlignVertical: "center",
+    ...Platform.select({
+      android: { includeFontPadding: false },
+      default: {},
+    }),
+  },
+});

--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -1,0 +1,98 @@
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useT } from "@/lib/i18n/LanguageProvider";
+import { useTheme } from "@/lib/theme/useTheme";
+
+export type ChipSize = "small" | "default";
+
+export const CHIP_HEIGHT_DEFAULT = 30;
+export const CHIP_HEIGHT_SMALL = 24;
+
+const SIZE_MAP: Record<
+  ChipSize,
+  { height: number; fontSize: number; iconSize: number; paddingLeft: number }
+> = {
+  small: {
+    height: CHIP_HEIGHT_SMALL,
+    fontSize: 12,
+    iconSize: 12,
+    paddingLeft: 10,
+  },
+  default: {
+    height: CHIP_HEIGHT_DEFAULT,
+    fontSize: 14,
+    iconSize: 14,
+    paddingLeft: 12,
+  },
+};
+
+type Props = {
+  label: string;
+  testID?: string;
+  size?: ChipSize;
+  onRemove?: () => void;
+  removeTestID?: string;
+};
+
+export function Chip({
+  label,
+  testID,
+  size = "default",
+  onRemove,
+  removeTestID,
+}: Props) {
+  const theme = useTheme();
+  const { t } = useT();
+  const sizing = SIZE_MAP[size];
+
+  return (
+    <View
+      testID={testID}
+      style={[
+        styles.chip,
+        {
+          backgroundColor: `${theme.colors.accent}26`,
+          height: sizing.height,
+          paddingLeft: sizing.paddingLeft,
+          paddingRight: onRemove ? sizing.paddingLeft - 4 : sizing.paddingLeft,
+        },
+      ]}
+    >
+      <Text
+        style={[
+          styles.label,
+          { fontSize: sizing.fontSize, color: theme.colors.accent },
+        ]}
+      >
+        {label}
+      </Text>
+      {onRemove && (
+        <Pressable
+          testID={removeTestID}
+          accessibilityRole="button"
+          accessibilityLabel={t("delete")}
+          onPress={onRemove}
+          style={styles.removeBtn}
+          hitSlop={6}
+        >
+          <Ionicons
+            name="close"
+            size={sizing.iconSize}
+            color={theme.colors.accent}
+          />
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 999,
+    gap: 4,
+  },
+  label: {},
+  removeBtn: { padding: 2 },
+});

--- a/docs/polish-backlog.md
+++ b/docs/polish-backlog.md
@@ -22,6 +22,13 @@
 
 ## Keyboard / Forms
 
+- [ ] **タグ編集 UI で「+ Add tag」ボタンと入力欄の幅が OS で揃わない。**
+  - 症状: タップして TextInput に切り替えると、iOS では TextInput の方が少し長く、Android では少し短い。
+  - 環境: iOS / Android で挙動が逆方向。表示・操作上は問題なし。
+  - 試したこと: minWidth 調整、onLayout でボタンの実測 width を TextInput に渡す方法、親 Pressable で囲んで中身だけ切り替える構造 — どれも完全には揃わなかった。React Native の TextInput が OS ごとに intrinsic padding / measure を持つことが原因。
+  - 方針: 一旦現状維持。改善方向は、外側を完全に同一の View でラップしつつ TextInput の native intrinsic padding を相殺する実装か、外側に width を固定で持たせる方向。
+  - 発見: `feature/tag-chips` 実機確認時。
+
 - [ ] **iOS で leave-guard の Cancel 後に戻るボタンが反応しなくなる。**
   - 症状: 編集画面で変更あり → `<` → 「Save changes?」alert → Cancel → 編集画面に戻る → `<` をもう一度タップしても無反応。スワイプ back するとリスト方向に動くが、一瞬で alert が再表示される。
   - 環境: iOS のみ（Android では問題なし）。Save / Discard / Delete 経路は正常。

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,7 @@
 jest.mock("@react-native-async-storage/async-storage", () =>
   require("@react-native-async-storage/async-storage/jest/async-storage-mock"),
 );
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));

--- a/lib/i18n/formatDate.test.ts
+++ b/lib/i18n/formatDate.test.ts
@@ -1,0 +1,23 @@
+import { formatDateTime } from "./formatDate";
+
+const ts = new Date("2026-06-07T20:45:00Z").getTime();
+
+describe("formatDateTime", () => {
+  it("formats English with year/month/day and 2-digit time", () => {
+    const out = formatDateTime(ts, "en");
+    expect(out).toMatch(/2026/);
+    expect(out).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("formats Japanese", () => {
+    const out = formatDateTime(ts, "ja");
+    expect(out).toMatch(/2026/);
+    expect(out).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("formats Korean", () => {
+    const out = formatDateTime(ts, "ko");
+    expect(out).toMatch(/2026/);
+    expect(out).toMatch(/\d{1,2}:\d{2}/);
+  });
+});

--- a/lib/i18n/formatDate.ts
+++ b/lib/i18n/formatDate.ts
@@ -1,0 +1,17 @@
+import type { Language } from "./translations";
+
+const LOCALE_MAP: Record<Language, string> = {
+  en: "en-US",
+  ja: "ja-JP",
+  ko: "ko-KR",
+};
+
+export function formatDateTime(timestamp: number, language: Language): string {
+  return new Date(timestamp).toLocaleString(LOCALE_MAP[language], {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -20,6 +20,7 @@ export const translations = {
     targetAmount: "Amount to make",
     addFlour: "Add flour",
     addIngredient: "Add ingredient",
+    addTag: "Add tag",
     tags: "Tags",
     bake: "Baking",
     temperatureC: "Temp (°C)",
@@ -28,6 +29,7 @@ export const translations = {
     discard: "Discard",
     unsavedTitle: "Save changes?",
     newRecipe: "New recipe",
+    lastUpdated: "Last updated {date}",
   },
   ja: {
     appName: "ぱんパーセント",
@@ -50,6 +52,7 @@ export const translations = {
     targetAmount: "作りたい量",
     addFlour: "粉を足す",
     addIngredient: "材料を足す",
+    addTag: "タグを足す",
     tags: "タグ",
     bake: "焼成",
     temperatureC: "温度 (°C)",
@@ -58,6 +61,7 @@ export const translations = {
     discard: "破棄",
     unsavedTitle: "変更を保存しますか？",
     newRecipe: "新しいレシピ",
+    lastUpdated: "最終更新 {date}",
   },
   ko: {
     appName: "빵 퍼센트",
@@ -80,6 +84,7 @@ export const translations = {
     targetAmount: "만들 양",
     addFlour: "가루 추가",
     addIngredient: "재료 추가",
+    addTag: "태그 추가",
     tags: "태그",
     bake: "굽기",
     temperatureC: "온도 (°C)",
@@ -88,6 +93,7 @@ export const translations = {
     discard: "버리기",
     unsavedTitle: "변경을 저장할까요?",
     newRecipe: "새 레시피",
+    lastUpdated: "{date} 최종 수정",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- Add a shared Chip component used by both the list and the editor; list cards show compact "small" chips, the editor shows default-size chips with a remove button
- Replace the comma-separated tag TextInput with a TagChips editor: dashed "+ Add tag" button, inline TextInput on tap, commit on submit or blur, duplicates and whitespace-only entries silently ignored
- Show a "Last updated {date}" line under the recipe name when editing, formatted per locale (Japanese and Korean place the date first) so two recipes with the same name can be distinguished
- Keyboard avoidance on iOS now uses useHeaderHeight as the offset so it stays correct regardless of header height (including iOS 26 Liquid Glass)
- Track the residual issue (tag input width does not perfectly match the "+ Add tag" button across iOS/Android) in the polish backlog

## Test plan

- [x] \`npm test\` (81 tests passing locally)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] On-device: add a tag, confirm chip appears
- [x] On-device: try to add a duplicate, confirm silently ignored
- [x] On-device: remove a chip via the × button
- [x] On-device: list screen shows tags as small chips with proper spacing from the recipe name
- [x] On-device: editor shows "Last updated YYYY/MM/DD HH:mm" for an existing recipe
- [x] On-device (ja/ko): timestamp is in the locale-appropriate order
- [x] On iOS: keyboard avoidance no longer leaves an awkward gap above the keyboard
- [ ] Tag input width perfectly matches "+ Add tag" button — **deferred** to polish backlog