### PR TITLE
feat: show ingredient preview line on recipe list cards

### DIFF
--- a/components/recipe/RecipeCard.test.tsx
+++ b/components/recipe/RecipeCard.test.tsx
@@ -35,4 +35,30 @@ describe("RecipeCard", () => {
 
     expect(onPress).toHaveBeenCalledTimes(1);
   });
+
+  it("shows a one-line preview with flour and top ingredients when available", () => {
+    const withIngredients: Recipe = {
+      ...recipe,
+      ingredients: [
+        { id: "flour", name: "Bread flour", grams: 500, isFlour: true },
+        { id: "water", name: "Water", grams: 350, isFlour: false },
+        { id: "salt", name: "Salt", grams: 10, isFlour: false },
+      ],
+    };
+
+    renderWithProvider(
+      <RecipeCard recipe={withIngredients} onPress={() => {}} />,
+    );
+
+    expect(screen.getByTestId("recipe-preview-r1")).toBeTruthy();
+    expect(
+      screen.getByText("Bread flour 500g · Water 350g · Salt 10g"),
+    ).toBeTruthy();
+  });
+
+  it("hides the preview line when there is nothing to summarize", () => {
+    renderWithProvider(<RecipeCard recipe={recipe} onPress={() => {}} />);
+
+    expect(screen.queryByTestId("recipe-preview-r1")).toBeNull();
+  });
 });

--- a/components/recipe/RecipeCard.tsx
+++ b/components/recipe/RecipeCard.tsx
@@ -1,6 +1,7 @@
 import { Image } from "expo-image";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Chip } from "@/components/ui/Chip";
+import { buildListPreview } from "@/lib/recipes/listPreview";
 import { useTheme } from "@/lib/theme/useTheme";
 import type { Recipe } from "@/types/recipe";
 
@@ -12,6 +13,7 @@ export function RecipeCard({
   onPress: () => void;
 }) {
   const theme = useTheme();
+  const preview = buildListPreview(recipe);
 
   return (
     <Pressable
@@ -37,6 +39,16 @@ export function RecipeCard({
         <Text style={[styles.name, { color: theme.colors.textPrimary }]}>
           {recipe.name}
         </Text>
+        {preview !== "" && (
+          <Text
+            testID={`recipe-preview-${recipe.id}`}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={[styles.preview, { color: theme.colors.textSecondary }]}
+          >
+            {preview}
+          </Text>
+        )}
         {recipe.tags.length > 0 && (
           <View style={styles.tags}>
             {recipe.tags.map((tag) => (
@@ -61,5 +73,6 @@ const styles = StyleSheet.create({
   thumb: { width: 56, height: 56, borderRadius: 12 },
   body: { flex: 1, gap: 6 },
   name: { fontSize: 18, fontWeight: "600" },
+  preview: { fontSize: 13 },
   tags: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
 });

--- a/lib/recipes/listPreview.test.ts
+++ b/lib/recipes/listPreview.test.ts
@@ -80,6 +80,17 @@ describe("buildListPreview", () => {
     expect(buildListPreview(r)).toBe("Bread flour 250.5g · Salt 1.5g");
   });
 
+  it("adds a thousands separator for large grams", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "flour", name: "Bread flour", grams: 1500, isFlour: true },
+        { id: "water", name: "Water", grams: 12000, isFlour: false },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe("Bread flour 1,500g · Water 12,000g");
+  });
+
   it("preserves the user's names across locales", () => {
     const r = recipe({
       ingredients: [

--- a/lib/recipes/listPreview.test.ts
+++ b/lib/recipes/listPreview.test.ts
@@ -1,0 +1,93 @@
+import type { Recipe } from "@/types/recipe";
+import { buildListPreview } from "./listPreview";
+
+const recipe = (overrides: Partial<Recipe>): Recipe => ({
+  id: "r1",
+  name: "Test",
+  ingredients: [],
+  tags: [],
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+describe("buildListPreview", () => {
+  it("lists every ingredient with its grams in the registered order", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "flour", name: "Bread flour", grams: 500, isFlour: true },
+        { id: "water", name: "Water", grams: 350, isFlour: false },
+        { id: "salt", name: "Salt", grams: 10, isFlour: false },
+        { id: "yeast", name: "Yeast", grams: 5, isFlour: false },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe(
+      "Bread flour 500g · Water 350g · Salt 10g · Yeast 5g",
+    );
+  });
+
+  it("includes every flour when multiple flours are blended", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "f1", name: "Bread flour", grams: 400, isFlour: true },
+        { id: "f2", name: "Whole wheat", grams: 100, isFlour: true },
+        { id: "water", name: "Water", grams: 350, isFlour: false },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe(
+      "Bread flour 400g · Whole wheat 100g · Water 350g",
+    );
+  });
+
+  it("omits ingredients with empty names or zero grams", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "flour", name: "Bread flour", grams: 500, isFlour: true },
+        { id: "water", name: "Water", grams: 350, isFlour: false },
+        { id: "empty", name: "", grams: 10, isFlour: false },
+        { id: "zero", name: "Salt", grams: 0, isFlour: false },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe("Bread flour 500g · Water 350g");
+  });
+
+  it("returns just the flour when there are no other ingredients", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "flour", name: "Bread flour", grams: 250, isFlour: true },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe("Bread flour 250g");
+  });
+
+  it("returns an empty string when nothing is filled in", () => {
+    const r = recipe({ ingredients: [] });
+    expect(buildListPreview(r)).toBe("");
+  });
+
+  it("formats decimal grams to one place", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "flour", name: "Bread flour", grams: 250.5, isFlour: true },
+        { id: "salt", name: "Salt", grams: 1.5, isFlour: false },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe("Bread flour 250.5g · Salt 1.5g");
+  });
+
+  it("preserves the user's names across locales", () => {
+    const r = recipe({
+      ingredients: [
+        { id: "flour", name: "強力粉", grams: 500, isFlour: true },
+        { id: "water", name: "水", grams: 350, isFlour: false },
+      ],
+    });
+
+    expect(buildListPreview(r)).toBe("強力粉 500g · 水 350g");
+  });
+});

--- a/lib/recipes/listPreview.ts
+++ b/lib/recipes/listPreview.ts
@@ -1,0 +1,15 @@
+import type { Recipe } from "@/types/recipe";
+
+const SEPARATOR = " · ";
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+export function buildListPreview(recipe: Recipe): string {
+  const parts = recipe.ingredients
+    .filter((i) => i.grams > 0 && i.name.trim() !== "")
+    .map((i) => `${i.name.trim()} ${formatNumber(i.grams)}g`);
+
+  return parts.join(SEPARATOR);
+}

--- a/lib/recipes/listPreview.ts
+++ b/lib/recipes/listPreview.ts
@@ -3,7 +3,10 @@ import type { Recipe } from "@/types/recipe";
 const SEPARATOR = " · ";
 
 function formatNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
 }
 
 export function buildListPreview(recipe: Recipe): string {


### PR DESCRIPTION
## Summary

- Add a \`buildListPreview\` helper that produces a single-line summary like \`Bread flour 500g · Water 350g · Salt 10g\` from a recipe's ingredients (every named ingredient with grams, registered order, " · " between).
- Render that line under the recipe name on each list card with \`numberOfLines={1}\` + \`ellipsizeMode="tail"\` so it always fits on one row.
- Hide the line entirely when there is nothing meaningful to show (all empty names / zero grams).
- Thousands-separate the grams (\`1,500g\`, \`12,000g\`) via toLocaleString so larger batches are easier to read at a glance.

The format is "all in grams" rather than mixing g and % so the list matches how home bakers usually read recipes; the detail screen keeps the baker's-percent view. Editing inputs, percentages, temperature, and minutes are intentionally left alone since they sit below the threshold or are typed directly by the user.

## Test plan

- [x] \`npm test\` (91 tests passing locally)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] On-device: list card shows \`{flour name} {g}g · {other} {g}g · ...\` using the actual names typed when the recipe was saved
- [x] On-device: blended flours appear individually (\`Bread flour 400g · Whole wheat 100g · ...\`)
- [x] On-device: long lines collapse to a tail-ellipsis instead of wrapping
- [x] On-device: recipes with no usable ingredients hide the preview line
- [x] On-device: large gram values render with a thousands separator (\`1,500g\`, \`12,000g\`)