### PR TITLE
feat: capture and display recipe photos

### DIFF
--- a/components/recipe/RecipeCard.tsx
+++ b/components/recipe/RecipeCard.tsx
@@ -1,3 +1,4 @@
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Image } from "expo-image";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Chip } from "@/components/ui/Chip";
@@ -32,8 +33,18 @@ export function RecipeCard({
         <Image source={{ uri: recipe.photoUri }} style={styles.thumb} />
       ) : (
         <View
-          style={[styles.thumb, { backgroundColor: theme.colors.border }]}
-        />
+          style={[
+            styles.thumb,
+            styles.thumbPlaceholder,
+            { backgroundColor: theme.colors.border },
+          ]}
+        >
+          <MaterialCommunityIcons
+            name="baguette"
+            size={24}
+            color={theme.colors.textSecondary}
+          />
+        </View>
       )}
       <View style={styles.body}>
         <Text style={[styles.name, { color: theme.colors.textPrimary }]}>
@@ -71,6 +82,7 @@ const styles = StyleSheet.create({
     padding: 12,
   },
   thumb: { width: 56, height: 56, borderRadius: 12 },
+  thumbPlaceholder: { alignItems: "center", justifyContent: "center" },
   body: { flex: 1, gap: 6 },
   name: { fontSize: 18, fontWeight: "600" },
   preview: { fontSize: 13 },

--- a/components/recipe/RecipeForm.tsx
+++ b/components/recipe/RecipeForm.tsx
@@ -17,6 +17,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlourPanel } from "@/components/recipe/form/FlourPanel";
 import { IngredientRow } from "@/components/recipe/form/IngredientRow";
+import { PhotoPicker } from "@/components/recipe/form/PhotoPicker";
 import { TagChips } from "@/components/recipe/form/TagChips";
 import { bakerPercents } from "@/lib/bakers/calculate";
 import { formatDateTime } from "@/lib/i18n/formatDate";
@@ -121,6 +122,10 @@ export function RecipeForm({ initial }: { initial: Recipe | null }) {
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
       >
+        <PhotoPicker
+          photoUri={form.draft.photoUri}
+          onChange={form.setPhotoUri}
+        />
         <TextInput
           testID="recipe-name"
           value={form.draft.name}

--- a/components/recipe/form/PhotoPicker.test.tsx
+++ b/components/recipe/form/PhotoPicker.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react-native";
+import { LanguageProvider } from "@/lib/i18n/LanguageProvider";
+import { PhotoPicker } from "./PhotoPicker";
+
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageCode: "en" }],
+}));
+jest.mock("expo-image-picker", () => ({
+  MediaTypeOptions: { Images: "Images" },
+  requestCameraPermissionsAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+const renderWithProvider = (ui: React.ReactElement) =>
+  render(<LanguageProvider>{ui}</LanguageProvider>);
+
+describe("PhotoPicker", () => {
+  it("shows a camera placeholder when no photo is set", () => {
+    renderWithProvider(
+      <PhotoPicker photoUri={undefined} onChange={() => {}} />,
+    );
+
+    expect(screen.getByTestId("photo-picker")).toBeTruthy();
+    expect(screen.queryByTestId("photo-picker-image")).toBeNull();
+    expect(screen.getByText("Add photo")).toBeTruthy();
+  });
+
+  it("shows the image when a photoUri is provided", () => {
+    renderWithProvider(
+      <PhotoPicker photoUri="file:///tmp/photo.jpg" onChange={() => {}} />,
+    );
+
+    expect(screen.getByTestId("photo-picker-image")).toBeTruthy();
+    expect(screen.queryByText("Add photo")).toBeNull();
+  });
+});

--- a/components/recipe/form/PhotoPicker.tsx
+++ b/components/recipe/form/PhotoPicker.tsx
@@ -1,0 +1,143 @@
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Image } from "expo-image";
+import * as ImagePicker from "expo-image-picker";
+import {
+  ActionSheetIOS,
+  Alert,
+  type AlertButton,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useT } from "@/lib/i18n/LanguageProvider";
+import { useTheme } from "@/lib/theme/useTheme";
+
+type Props = {
+  photoUri: string | undefined;
+  onChange: (photoUri: string | undefined) => void;
+};
+
+export function PhotoPicker({ photoUri, onChange }: Props) {
+  const theme = useTheme();
+  const { t } = useT();
+
+  const launchCamera = async () => {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(t("photoPermissionTitle"), t("photoPermissionMessage"));
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.8,
+    });
+    if (!result.canceled && result.assets[0]) {
+      onChange(result.assets[0].uri);
+    }
+  };
+
+  const launchLibrary = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(t("photoPermissionTitle"), t("photoPermissionMessage"));
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.8,
+    });
+    if (!result.canceled && result.assets[0]) {
+      onChange(result.assets[0].uri);
+    }
+  };
+
+  const remove = () => onChange(undefined);
+
+  const showActionSheet = () => {
+    const hasPhoto = !!photoUri;
+
+    if (Platform.OS === "ios") {
+      const options = hasPhoto
+        ? [t("takePhoto"), t("pickFromLibrary"), t("removePhoto"), t("cancel")]
+        : [t("takePhoto"), t("pickFromLibrary"), t("cancel")];
+      const cancelButtonIndex = options.length - 1;
+      const destructiveButtonIndex = hasPhoto ? 2 : undefined;
+      ActionSheetIOS.showActionSheetWithOptions(
+        { options, cancelButtonIndex, destructiveButtonIndex },
+        (index) => {
+          if (index === 0) launchCamera();
+          else if (index === 1) launchLibrary();
+          else if (hasPhoto && index === 2) remove();
+        },
+      );
+      return;
+    }
+
+    const buttons: AlertButton[] = [
+      { text: t("takePhoto"), onPress: launchCamera },
+      { text: t("pickFromLibrary"), onPress: launchLibrary },
+    ];
+    if (hasPhoto) {
+      buttons.push({
+        text: t("removePhoto"),
+        style: "destructive",
+        onPress: remove,
+      });
+    }
+    buttons.push({ text: t("cancel"), style: "cancel" });
+    Alert.alert(t("addPhoto"), undefined, buttons);
+  };
+
+  return (
+    <Pressable
+      testID="photo-picker"
+      accessibilityRole="button"
+      accessibilityLabel={photoUri ? t("addPhoto") : t("addPhoto")}
+      onPress={showActionSheet}
+      style={[
+        styles.frame,
+        {
+          backgroundColor: theme.colors.surface,
+          borderColor: theme.colors.border,
+        },
+      ]}
+    >
+      {photoUri ? (
+        <Image
+          testID="photo-picker-image"
+          source={{ uri: photoUri }}
+          style={styles.image}
+          contentFit="contain"
+        />
+      ) : (
+        <View style={styles.placeholder}>
+          <MaterialCommunityIcons
+            name="baguette"
+            size={48}
+            color={theme.colors.textSecondary}
+          />
+          <Text style={[styles.hint, { color: theme.colors.textSecondary }]}>
+            {t("addPhoto")}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  frame: {
+    width: "100%",
+    aspectRatio: 2 / 1,
+    borderRadius: 16,
+    borderWidth: 1,
+    overflow: "hidden",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  image: { width: "100%", height: "100%" },
+  placeholder: { alignItems: "center", gap: 6 },
+  hint: { fontSize: 13 },
+});

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -30,6 +30,13 @@ export const translations = {
     unsavedTitle: "Save changes?",
     newRecipe: "New recipe",
     lastUpdated: "Last updated {date}",
+    addPhoto: "Add photo",
+    takePhoto: "Take a photo",
+    pickFromLibrary: "Choose from library",
+    removePhoto: "Remove photo",
+    photoPermissionTitle: "Permission needed",
+    photoPermissionMessage:
+      "Please enable photo access in Settings to add a picture.",
   },
   ja: {
     appName: "ぱんパーセント",
@@ -62,6 +69,12 @@ export const translations = {
     unsavedTitle: "変更を保存しますか？",
     newRecipe: "新しいレシピ",
     lastUpdated: "最終更新 {date}",
+    addPhoto: "写真を追加",
+    takePhoto: "カメラで撮る",
+    pickFromLibrary: "ライブラリから選ぶ",
+    removePhoto: "写真を削除",
+    photoPermissionTitle: "権限が必要です",
+    photoPermissionMessage: "設定から写真アクセスを許可してください。",
   },
   ko: {
     appName: "빵 퍼센트",
@@ -94,6 +107,12 @@ export const translations = {
     unsavedTitle: "변경을 저장할까요?",
     newRecipe: "새 레시피",
     lastUpdated: "{date} 최종 수정",
+    addPhoto: "사진 추가",
+    takePhoto: "카메라로 촬영",
+    pickFromLibrary: "라이브러리에서 선택",
+    removePhoto: "사진 삭제",
+    photoPermissionTitle: "권한이 필요합니다",
+    photoPermissionMessage: "설정에서 사진 접근을 허용해 주세요.",
   },
 } as const;
 

--- a/lib/recipes/useRecipeForm.test.tsx
+++ b/lib/recipes/useRecipeForm.test.tsx
@@ -83,6 +83,18 @@ describe("useRecipeForm", () => {
     expect(result.current.draft.ingredients.length).toBe(before);
   });
 
+  it("sets and clears the photo uri", () => {
+    const { result } = renderHook(() => useRecipeForm(null));
+
+    expect(result.current.draft.photoUri).toBeUndefined();
+
+    act(() => result.current.setPhotoUri("file:///tmp/photo.jpg"));
+    expect(result.current.draft.photoUri).toBe("file:///tmp/photo.jpg");
+
+    act(() => result.current.setPhotoUri(undefined));
+    expect(result.current.draft.photoUri).toBeUndefined();
+  });
+
   it("does not change grams when there is no flour", () => {
     const initial = recipe([
       { id: "water", name: "水", grams: 100, isFlour: false },

--- a/lib/recipes/useRecipeForm.ts
+++ b/lib/recipes/useRecipeForm.ts
@@ -25,6 +25,7 @@ export type RecipeFormApi = {
   setTags: (tags: string[]) => void;
   setBake: (bake: Bake | undefined) => void;
   setMemo: (memo: string) => void;
+  setPhotoUri: (photoUri: string | undefined) => void;
 };
 
 function isValidDraft(d: RecipeDraft): boolean {
@@ -137,5 +138,6 @@ export function useRecipeForm(initial: Recipe | null): RecipeFormApi {
     setTags: (tags) => setDraft((d) => ({ ...d, tags })),
     setBake: (bake) => setDraft((d) => ({ ...d, bake })),
     setMemo: (memo) => setDraft((d) => ({ ...d, memo })),
+    setPhotoUri: (photoUri) => setDraft((d) => ({ ...d, photoUri })),
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-crypto": "15.0.9",
         "expo-font": "14.0.12",
         "expo-image": "3.0.11",
+        "expo-image-picker": "~17.0.11",
         "expo-linking": "8.0.12",
         "expo-localization": "17.0.9",
         "expo-router": "6.0.24",
@@ -5314,6 +5315,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.11.tgz",
+      "integrity": "sha512-/apkoyukDvsCHHb9fzP+F34A1uQqSzUtYH/2P/xJACNEwq+mwEXjXvVU8bzlJq6ih0Qo1+tpVivIa7B9kYSwOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo-crypto": "15.0.9",
     "expo-font": "14.0.12",
     "expo-image": "3.0.11",
+    "expo-image-picker": "17.0.11",
     "expo-linking": "8.0.12",
     "expo-localization": "17.0.9",
     "expo-router": "6.0.24",


### PR DESCRIPTION
## Summary

- Add a PhotoPicker above the recipe name in the form: 2:1 framed placeholder (baguette icon + "Add photo") when empty, the chosen image with \`contentFit="contain"\` so portrait shots show fully when set
- Tapping opens the native iOS ActionSheet / Android Alert with Take a photo / Choose from library / Remove photo (Remove only when a photo exists)
- Permissions are requested through expo-image-picker; denial surfaces a localized alert and leaves the existing photo as-is
- \`useRecipeForm\` gains a \`setPhotoUri\` action and the new strings are translated for en/ja/ko
- The recipe list card replaces its flat gray placeholder with the same baguette icon so the editor and the list speak the same visual language for "no photo yet"

## Test plan

- [x] \`npm test\` (94 tests passing locally)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] On-device: new recipe screen shows the baguette placeholder above the name field
- [x] On-device: tapping the placeholder opens the action sheet / alert (Take a photo / Choose from library / Cancel)
- [x] On-device: snapping a photo / picking from the library shows it inside the frame (contentFit="contain" so portrait images keep both top and bottom visible)
- [x] On-device: tapping a saved photo offers Remove and clears it
- [x] On-device: denying camera or library permission shows a localized alert and keeps the existing state
- [x] On-device: saved photo appears in the list card thumbnail
- [x] On-device: list cards without a photo show the same baguette placeholder